### PR TITLE
DOP-131837 remove AWSPowerShell dependency

### DIFF
--- a/PSAX.psm1
+++ b/PSAX.psm1
@@ -1,5 +1,3 @@
-Import-Module AWSPowerShell
-
 $moduleRoot = Split-Path -Path $MyInvocation.MyCommand.Path
 
 "$moduleRoot\Functions\*.ps1" |


### PR DESCRIPTION
Misha confirms the services still work and service startup/deployment time is reduced. Please see the full message in my comment in the JIRA card
